### PR TITLE
fix: travis build by removing unnecessary istanbul plugin in test

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -14,9 +14,6 @@
           }
         ]
       ]
-    },
-    "test": {
-      "plugins": ["istanbul"]
     }
   }
 }


### PR DESCRIPTION
TIL `babel-jest` does this already, though, the latest versions of `babel-jest` (v19.0.x at time of writing) are broken ATM.